### PR TITLE
Add type pattern matching and compilation

### DIFF
--- a/src/localtypes.ml
+++ b/src/localtypes.ml
@@ -17,12 +17,12 @@ and show_term_list = function
   | (x::xs) -> show_term x ^ ", " ^ show_term_list xs
 
 and show_pattern = function
-    PVar(x) -> x
+    PVar(x, None) -> x
+  | PVar(x, dt) -> x ^ ": " ^ show_dtype dt
   | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PForm(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-  | PMatch(t, None) -> "=" ^ show_term t
-  | PMatch(t, dt) -> show_term t ^ ": " ^ show_dtype dt
+  | PMatch(t) -> "=" ^ show_term t
 
 and show_pattern_list = function
     [] -> ""
@@ -68,7 +68,7 @@ and unwrapGlobal global local =
 and to_local_type global_type participant =
   match global_type with
     Send(sender, receiver, opt, x, t, g) when participant = sender -> LSend((if receiver < sender then receiver ^ sender else sender ^ receiver), opt, t, to_local_type g participant)
-  | Send(sender, receiver, opt, x, t, g) when participant = receiver -> LRecv((if receiver < sender then receiver ^ sender else sender ^ receiver), opt, PVar(x), t, to_local_type g participant)
+  | Send(sender, receiver, opt, x, t, g) when participant = receiver -> LRecv((if receiver < sender then receiver ^ sender else sender ^ receiver), opt, PVar(x, None), t, to_local_type g participant)
   | Send(_, _, _, _, _, g) -> to_local_type g participant
   | Compute(p, letb, g) when participant = p -> local_let_bind letb (to_local_type g participant)
   | Compute(p, letb, g) -> (to_local_type g participant)

--- a/src/localtypes.ml
+++ b/src/localtypes.ml
@@ -21,7 +21,8 @@ and show_pattern = function
   | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PForm(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-  | PMatch(t) -> "=" ^ show_term t
+  | PMatch(t, None) -> "=" ^ show_term t
+  | PMatch(t, dt) -> show_term t ^ ": " ^ show_dtype dt
 
 and show_pattern_list = function
     [] -> ""

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -88,8 +88,10 @@ pattern:
 | LEFT_PAR; p = pattern; RIGHT_PAR {p}
 | name = ID
   { PVar(name) }
-| PCT; t = term
-  { PMatch(t) }
+| PCT; EQ; t = term
+  { PMatch(t, None) }
+| PCT; t = term; COLON; dt = data_type
+  { PMatch(t, dt) }
 | name = ID; LEFT_PAR; pargs = pattern_list; RIGHT_PAR
   { PFunc(name, pargs) }
 | name = ID; LEFT_ANGLE; pargs = pattern_list; RIGHT_ANGLE

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -87,11 +87,11 @@ data_type_list:
 pattern:
 | LEFT_PAR; p = pattern; RIGHT_PAR {p}
 | name = ID
-  { PVar(name) }
-| PCT; EQ; t = term
-  { PMatch(t, None) }
-| PCT; t = term; COLON; dt = data_type
-  { PMatch(t, dt) }
+  { PVar(name, None) }
+| name = ID; COLON; dt = data_type
+  { PVar(name, dt) }
+| PCT; t = term
+  { PMatch(t) }
 | name = ID; LEFT_PAR; pargs = pattern_list; RIGHT_PAR
   { PFunc(name, pargs) }
 | name = ID; LEFT_ANGLE; pargs = pattern_list; RIGHT_ANGLE

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -32,7 +32,7 @@ and translatePattern pat (conditions : (term * term) list) =
     PVar(x) -> ((ID(x)), conditions)
   | PForm(fname, args) ->
     ((ID(fname)), (combineConditions args))
-  | PMatch(t) ->
+  | PMatch(t, _) ->
       let var = next_var() in
       (ID(var), (t, Var(var))::conditions)
 
@@ -67,7 +67,7 @@ and process = function
     let strPtn = StructPattern(ID(fname), pats) in
     if(conditions = []) then SDeclExp(PatrExp(strPtn, translateTerm term))::process local_type
     else SDeclExp(PatrExp(strPtn, translateTerm term))::[SIfStatement(If((equals_condition_patterns conditions), BStmts(process local_type)))]
-  | LLet (PMatch(mat), term, local_type) ->
+  | LLet (PMatch(mat, None), term, local_type) ->
     [SIfStatement(If(OExp(translateTerm mat, Equals, translateTerm term), BStmts(process local_type)))]
   | LLet (ident, term, local_type) ->
     let patterns = translatePattern ident [] in

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -29,10 +29,10 @@ and combineConditions cons =
 
 and translatePattern pat (conditions : (term * term) list) =
   match pat with
-    PVar(x) -> ((ID(x)), conditions)
+    PVar(x, _) -> ((ID(x)), conditions)
   | PForm(fname, args) ->
     ((ID(fname)), (combineConditions args))
-  | PMatch(t, _) ->
+  | PMatch(t) ->
       let var = next_var() in
       (ID(var), (t, Var(var))::conditions)
 
@@ -58,7 +58,7 @@ and equals_condition_patterns = function
 and process = function
     LSend(_, opt, Form(fname, args), local_type) ->
     let send = toFunction "send" (Exps([Id(ID("c")); ((EStruct(ID(fname ), StructValues((List.map (fun a -> StructValue(translateTerm a)) args)))))])) in
-    SDeclExp(DeclExp(fst(translatePattern (PVar "c") []), send))::process local_type
+    SDeclExp(DeclExp(fst(translatePattern (PVar ("c", None)) []), send))::process local_type
   | LNew (ident, data_type, local_type) -> (fresh ident data_type)::process local_type
   | LLet (PForm(fname, args), term, local_type) ->
     let patterns = List.map (fun a -> translatePattern (a) []) args in
@@ -67,7 +67,7 @@ and process = function
     let strPtn = StructPattern(ID(fname), pats) in
     if(conditions = []) then SDeclExp(PatrExp(strPtn, translateTerm term))::process local_type
     else SDeclExp(PatrExp(strPtn, translateTerm term))::[SIfStatement(If((equals_condition_patterns conditions), BStmts(process local_type)))]
-  | LLet (PMatch(mat, None), term, local_type) ->
+  | LLet (PMatch(mat), term, local_type) ->
     [SIfStatement(If(OExp(translateTerm mat, Equals, translateTerm term), BStmts(process local_type)))]
   | LLet (ident, term, local_type) ->
     let patterns = translatePattern ident [] in
@@ -77,9 +77,9 @@ and process = function
     else begin
       [SIfStatement(If((equals_condition_patterns conditions), BStmts(process local_type)))]
     end
-  | LRecv (_, opt, PVar(x), term, LLet (PForm(fname, args), Var(xx), local_type)) ->
+  | LRecv (_, opt, PVar(x, _), term, LLet (PForm(fname, args), Var(xx), local_type)) ->
     SDeclExp(DeclExp((ID("(c," ^x ^ ")")), toFunction "recv" (Id(ID("c")))))::SDeclExp(PatrExp(toStructPattern fname args, Id(ID(xx))))::process local_type
-  | LRecv (_, opt, PVar(x), term, local_type) ->  SDeclExp(DeclExp((ID(x)), toFunction ("recv") (Id(ID("c")))))::process local_type
+  | LRecv (_, opt, PVar(x, _), term, local_type) ->  SDeclExp(DeclExp((ID(x)), toFunction ("recv") (Id(ID("c")))))::process local_type
   | LEvent (ident, term, local_type) -> process local_type
   | LLocalEnd -> [SExp(toFunction "close" (Id(ID("c"))))]
   | _ -> [End]

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -51,10 +51,10 @@ and term_as_type_list = function
   | (x::xs) -> abstract_type ^ ", " ^ term_as_type_list xs
 
 and pattern = function
-    PVar(x) -> abstract_type
+    PVar(x, _) -> abstract_type
   | PFunc(name, args) -> name ^ "(" ^ pattern_list args ^ ")"
   | PTuple(args) -> "pair(" ^ pattern_list args ^ ")"
-  | PMatch(t, _) -> "=" ^ term_as_type t
+  | PMatch(t) -> "=" ^ term_as_type t
 
 and pattern_list = function
     [] -> ""
@@ -62,11 +62,11 @@ and pattern_list = function
   | (x::xs) -> pattern x ^ ", " ^ pattern_list xs
 
   and show_pattern = function
-      PVar(x) -> x
+      PVar(x, _) -> x
     | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
     | PForm(fname, args) -> show_format fname ^ "(" ^ show_pattern_list args ^ ")"
     | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-    | PMatch(t, _) -> "=" ^ show_term t
+    | PMatch(t) -> "=" ^ show_term t
 
   and show_pattern_list = function
       [] -> ""
@@ -102,7 +102,7 @@ and fresh t =
 and process = function
     LSend(_, opt, t, local_type) -> indent ^ "let c = c.send(" ^ show_term t ^ ");\n" ^ process local_type
   | LNew (ident, data_type, local_type) -> indent ^ "let " ^ ident ^ " = " ^ "f." ^ fresh data_type ^ "();\n" ^ process local_type
-  | LLet (PMatch(ident, None), term, local_type) ->
+  | LLet (PMatch(ident), term, local_type) ->
     indent ^ "if " ^ show_term ident ^ " != " ^ show_term term ^ " { panic!(\"" ^show_term ident ^ " does not match " ^ show_term term  ^"\") };\n" ^ process local_type
   | LLet (ident, term, local_type) -> indent ^ "let " ^ show_pattern ident ^ " = " ^ show_term term ^ ";\n" ^ process local_type
   | LRecv (_, opt, pattern, term, local_type) ->  indent ^ "let (c, " ^ show_pattern pattern ^") = c.recv();\n" ^ process local_type

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -54,7 +54,7 @@ and pattern = function
     PVar(x) -> abstract_type
   | PFunc(name, args) -> name ^ "(" ^ pattern_list args ^ ")"
   | PTuple(args) -> "pair(" ^ pattern_list args ^ ")"
-  | PMatch(t) -> "=" ^ term_as_type t
+  | PMatch(t, _) -> "=" ^ term_as_type t
 
 and pattern_list = function
     [] -> ""
@@ -66,7 +66,7 @@ and pattern_list = function
     | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
     | PForm(fname, args) -> show_format fname ^ "(" ^ show_pattern_list args ^ ")"
     | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-    | PMatch(t) -> "=" ^ show_term t
+    | PMatch(t, _) -> "=" ^ show_term t
 
   and show_pattern_list = function
       [] -> ""
@@ -102,7 +102,7 @@ and fresh t =
 and process = function
     LSend(_, opt, t, local_type) -> indent ^ "let c = c.send(" ^ show_term t ^ ");\n" ^ process local_type
   | LNew (ident, data_type, local_type) -> indent ^ "let " ^ ident ^ " = " ^ "f." ^ fresh data_type ^ "();\n" ^ process local_type
-  | LLet (PMatch(ident), term, local_type) ->
+  | LLet (PMatch(ident, None), term, local_type) ->
     indent ^ "if " ^ show_term ident ^ " != " ^ show_term term ^ " { panic!(\"" ^show_term ident ^ " does not match " ^ show_term term  ^"\") };\n" ^ process local_type
   | LLet (ident, term, local_type) -> indent ^ "let " ^ show_pattern ident ^ " = " ^ show_term term ^ ";\n" ^ process local_type
   | LRecv (_, opt, pattern, term, local_type) ->  indent ^ "let (c, " ^ show_pattern pattern ^") = c.recv();\n" ^ process local_type

--- a/src/types.ml
+++ b/src/types.ml
@@ -9,6 +9,7 @@ type data_type =
     DType of ident
   | DAType of ident * ident
   | AType of ident
+  | None
 (* Terms *)
 type term =
     Var of ident
@@ -24,13 +25,13 @@ type term =
 type pattern =
     PVar of ident
   | PForm of ident * pattern list
-  | PMatch of term
+  | PMatch of term * data_type
   | PFunc of ident * pattern list
   | PTuple of pattern list
 
 let rec pattern_to_term = function
     PVar x -> Var x
-  | PMatch t -> t
+  | PMatch(t, _) -> t
   | PFunc(f, args) -> Func(f, List.map pattern_to_term args)
   | PTuple args -> Tuple(List.map pattern_to_term args)
 
@@ -47,7 +48,7 @@ type let_bind =
 
 let rec binds = function
     PVar x -> [x]
-  | PMatch t -> []
+  | PMatch(t, _) -> []
   | PFunc(_, args) | PForm(_, args) | PTuple args -> List.concat (List.map binds args)
 
 (* Channel options / Bullet notation *)
@@ -125,7 +126,7 @@ and show_pattern = function
   | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PForm(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-  | PMatch(t) -> "=" ^ show_term t
+  | PMatch(t, _) -> "=" ^ show_term t
 
 and show_pattern_list = function
     [] -> ""

--- a/src/types.ml
+++ b/src/types.ml
@@ -23,15 +23,15 @@ type term =
 
 (* Pattern *)
 type pattern =
-    PVar of ident
+    PVar of ident * data_type
   | PForm of ident * pattern list
-  | PMatch of term * data_type
+  | PMatch of term
   | PFunc of ident * pattern list
   | PTuple of pattern list
 
 let rec pattern_to_term = function
-    PVar x -> Var x
-  | PMatch(t, _) -> t
+    PVar(x, _) -> Var x
+  | PMatch t -> t
   | PFunc(f, args) -> Func(f, List.map pattern_to_term args)
   | PTuple args -> Tuple(List.map pattern_to_term args)
 
@@ -47,8 +47,8 @@ type let_bind =
   | LetEnd
 
 let rec binds = function
-    PVar x -> [x]
-  | PMatch(t, _) -> []
+    PVar(x, _) -> [x]
+  | PMatch t -> []
   | PFunc(_, args) | PForm(_, args) | PTuple args -> List.concat (List.map binds args)
 
 (* Channel options / Bullet notation *)
@@ -122,11 +122,11 @@ and show_term_list = function
   | (x::xs) -> show_term x ^ ", " ^ show_term_list xs
 
 and show_pattern = function
-    PVar(x) -> x
+    PVar(x, _) -> x
   | PFunc(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PForm(name, args) -> name ^ "(" ^ show_pattern_list args ^ ")"
   | PTuple(args) -> "<" ^ show_pattern_list args ^ ">"
-  | PMatch(t, _) -> "=" ^ show_term t
+  | PMatch(t) -> "=" ^ show_term t
 
 and show_pattern_list = function
     [] -> ""


### PR DESCRIPTION
Extends the syntax support for pattern matching, as well as adds the corresponding ProVerif interpretation.

Pattern matching syntax A&B notation:
```
let M1<%ct> = x;
```


> ProVerif output
```
let M1(=ct) = x in
```


When having that ⬆️ in ProVerif, we need to make sure we have the `ct` var (in this case) defined upfront ❗ 