### PR TITLE
If assignment syntax parsed from A & B notation

### DIFF
--- a/AccountableWarrantExecution.ab
+++ b/AccountableWarrantExecution.ab
@@ -49,8 +49,8 @@ Log -> Decryptor: y = M4<zkp>
 Decryptor {
     let M3<blindid> = x;
     let M4<zkp> = y;
-    if (checkzkp(pk(isk), blindid, zkp) = OK) {
-        let sk = blindextract(msk, blindid);
+    checkzkp(pk(isk), blindid, zkp)
+    let sk = blindextract(msk, blindid);
     }
 }
 Decryptor *->* Investigator: z = M5<sk>

--- a/AccountableWarrantExecution.ab
+++ b/AccountableWarrantExecution.ab
@@ -49,8 +49,8 @@ Log -> Decryptor: y = M4<zkp>
 Decryptor {
     let M3<blindid> = x;
     let M4<zkp> = y;
-    checkzkp(pk(isk), blindid, zkp)
-    let sk = blindextract(msk, blindid);
+    new sk': skey;
+    let sk = if(checkzkp(pk(isk), blindid, zkp) = OK, blindextract(msk, blindid), sk');
 }
 Decryptor *->* Investigator: z = M5<sk>
 Investigator {

--- a/AccountableWarrantExecution.ab
+++ b/AccountableWarrantExecution.ab
@@ -51,7 +51,6 @@ Decryptor {
     let M4<zkp> = y;
     checkzkp(pk(isk), blindid, zkp)
     let sk = blindextract(msk, blindid);
-    }
 }
 Decryptor *->* Investigator: z = M5<sk>
 Investigator {

--- a/DiffieHellman.ab
+++ b/DiffieHellman.ab
@@ -3,7 +3,7 @@ Principals: Alice, Bob;
 Types: key;
 Functions: exp(key, key) -> key, g() -> key; 
 Equations: exp(exp(g(),y),x) = exp(exp(g(),x),y);
-Formats: M1(key), M2(key);
+Formats: M1(key), M2(key), M3(key);
 Protocol:
 Alice {
     new x: key;
@@ -19,7 +19,14 @@ Bob {
 Bob -> Alice: b = M2<gy>
 Alice {
     let M2<gy> = b;
-    let gxy = exp(gy, x);
+    let gyx = exp(gy, x);
+}
+Alice -> Bob: c = M3<gyx>
+Bob {
+    let M3<gyx> = c;
+    new t: key;
+    new f: key;
+    let result = if(gxy = gyx, t, f);
 }
 end
 

--- a/DiffieHellman.ab
+++ b/DiffieHellman.ab
@@ -3,7 +3,7 @@ Principals: Alice, Bob;
 Types: key;
 Functions: exp(key, key) -> key, g() -> key; 
 Equations: exp(exp(g(),y),x) = exp(exp(g(),x),y);
-Formats: M1(key), M2(key), M3(key);
+Formats: M1(key), M2(key);
 Protocol:
 Alice {
     new x: key;
@@ -20,13 +20,6 @@ Bob -> Alice: b = M2<gy>
 Alice {
     let M2<gy> = b;
     let gyx = exp(gy, x);
-}
-Alice -> Bob: c = M3<gyx>
-Bob {
-    let M3<gyx> = c;
-    new t: key;
-    new f: key;
-    let result = if(gxy = gyx, t, f);
 }
 end
 

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -53,7 +53,6 @@ rule read =
   | "with"   { WITH }
   | "data"   { DATA }
   | "if"     { IF }
-  | "else"   { ELSE }
   | "dishonest"  { DISHONEST }
   | "Problem"    { PROBLEM }
   | "Principals" { PRINCIPALS }

--- a/src/localtypes.ml
+++ b/src/localtypes.ml
@@ -39,8 +39,6 @@ and local_let_bind types g =
       New(name, data_type, letb) -> LNew(name, data_type, local_let_bind letb g)
     | Let(p, t, letb) -> LLet(p, t, local_let_bind letb g)
     | LetEnd -> g
-    | If(cond, ifl, LetEnd, letb) -> LIf(cond, local_let_bind ifl g, LLocalEnd, local_let_bind letb g) 
-    | If(cond, ifl, ifr, letb) -> LIf(cond, local_let_bind ifl g, local_let_bind ifr g, local_let_bind letb g) 
     | Event (ident, terms, letb) -> LEvent(ident, terms, local_let_bind letb g)
 
 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -7,7 +7,7 @@
 %token COMMA COLON SEMI PCT ARROW AT AUTH CONF AUTHCONF
 %token LEFT_PAR RIGHT_PAR LEFT_ANGLE RIGHT_ANGLE LEFT_BRACE RIGHT_BRACE LEFT_BRACK RIGHT_BRACK
 %token EQ AND OR NOT DIV PLUS
-%token NEW LET EVENT IN END MATCH WITH DATA IF ELSE
+%token NEW LET EVENT IN END MATCH WITH DATA IF
 %token PROBLEM PRINCIPALS KNOWLEDGE TYPES FUNCTIONS EQUATIONS FORMATS PROTOCOL DISHONEST LEMMA
 %token EOF
 
@@ -70,7 +70,9 @@ term:
 | NOT; t = term
   { Not(t) }
 | LEFT_PAR; t = term; RIGHT_PAR
-  { t };
+  { t }
+| IF; LEFT_PAR; cond = term; COMMA; tterm = term; COMMA; fterm = term; RIGHT_PAR
+  { If(cond, tterm, fterm) };
 
 term_list:
 | l = separated_list(COMMA, term)
@@ -85,7 +87,8 @@ data_type_list:
     { l };
 
 pattern:
-| LEFT_PAR; p = pattern; RIGHT_PAR {p}
+| LEFT_PAR; p = pattern; RIGHT_PAR 
+  { p }
 | name = ID
   { PVar(name) }
 | PCT; t = term
@@ -108,10 +111,6 @@ let_bind:
   { Let(p, t, letb) }
 | EVENT; name = ID; LEFT_PAR; ts = term_list; RIGHT_PAR; SEMI; letb = let_bind
   { Event(name, ts, letb) }
-| IF; LEFT_PAR; cond = term; RIGHT_PAR; LEFT_BRACE; ifl = let_bind; RIGHT_BRACE; ELSE; LEFT_BRACE; ifr = let_bind; RIGHT_BRACE; letb = let_bind
-  { If(cond, ifl, ifr, letb) }
-| IF; LEFT_PAR; cond = term; RIGHT_PAR; LEFT_BRACE; ifl = let_bind; RIGHT_BRACE; letb = let_bind
-  { If(cond, ifl, LetEnd, letb) }
 | { LetEnd };
 
 channel_option:

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -21,7 +21,7 @@ let rec show_term = function
   | And(t1, t2) -> show_term t1 ^ " && " ^ show_term t2
   | Or(t1, t2) -> show_term t1 ^ " || " ^ show_term t2
   | Not(t) -> "not(" ^ show_term t ^ ")"
-  | If(cond, tterm, fterm) -> "(if(" ^ show_term cond ^ ") then " ^ show_term tterm ^ " else " ^ show_term fterm ^ ")"
+  | If(cond, tterm, fterm) -> "( if(" ^ show_term cond ^ ") then " ^ show_term tterm ^ " else " ^ show_term fterm ^ " )"
 
 let rec build_equation_params t pos function_types names_and_types = (* [(var name, type)...] *)
   match (t, function_types) with

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -21,7 +21,7 @@ let rec show_term = function
   | And(t1, t2) -> show_term t1 ^ " && " ^ show_term t2
   | Or(t1, t2) -> show_term t1 ^ " || " ^ show_term t2
   | Not(t) -> "not(" ^ show_term t ^ ")"
-  | If(cond, tterm, fterm) -> "if(" ^ show_term cond ^ ", " ^ show_term tterm ^ ", " ^ show_term fterm ^ ")"
+  | If(cond, tterm, fterm) -> "(if(" ^ show_term cond ^ ") then " ^ show_term tterm ^ " else " ^ show_term fterm ^ ")"
 
 let rec build_equation_params t pos function_types names_and_types = (* [(var name, type)...] *)
   match (t, function_types) with

--- a/src/types.ml
+++ b/src/types.ml
@@ -19,6 +19,7 @@ type term =
   | And of term * term
   | Or of term * term
   | Not of term
+  | If of term * term * term
 
 (* Pattern *)
 type pattern =
@@ -42,7 +43,6 @@ type let_bind =
     New of ident * data_type * let_bind
   | Let of pattern * term * let_bind
   | Event of ident * term list * let_bind
-  | If of term * let_bind * let_bind * let_bind
   | LetEnd
 
 let rec binds = function
@@ -74,7 +74,6 @@ type local_type =
   | LBranch of principal * (pattern * local_type) list
   | LNew of ident * data_type * local_type
   | LLet of pattern * term * local_type
-  | LIf of term * local_type * local_type * local_type
   | LEvent of ident * term list * local_type
   | LDefLocal of ident * ident list * local_type * local_type
   | LCallLocal of ident * term list * local_type
@@ -113,6 +112,7 @@ let rec show_term = function
   | And(t1, t2) -> show_term t1 ^ " & " ^ show_term t2
   | Or(t1, t2) -> show_term t1 ^ " | " ^ show_term t2
   | Not(t) -> "~" ^ show_term t
+  | If(cond, tterm, fterm) -> "if(" ^ show_term cond ^ ", " ^ show_term tterm ^ ", " ^ show_term fterm ^ ")"
 
 (* List options: empty, single item, list *)
 and show_term_list = function
@@ -141,8 +141,6 @@ and show_let_bind = function
     New(name, data_type, letb) -> "  " ^ "new " ^ name ^ ";\n" ^ show_let_bind letb
   | Let(p, t, letb) -> "let " ^ show_pattern p ^ " = " ^ show_term t ^ " in\n" ^ show_let_bind letb
   | Event(f, args, letb) -> "event " ^ f ^ "("^ show_term_list args ^ ")\n" ^ show_let_bind letb
-  | If(cond, ifl, LetEnd, letb) -> "if (" ^ show_term cond ^ ") {\n" ^ show_let_bind ifl ^ "}\n" ^ show_let_bind letb
-  | If(cond, ifl, ifr, letb) -> "if (" ^ show_term cond ^ ") {\n" ^ show_let_bind ifl ^ "} else {\n" ^ show_let_bind ifr ^ "}" ^ show_let_bind letb
   | LetEnd -> ""
 
 and show_channel_option = function


### PR DESCRIPTION
Introduced **if** as a term in a `let` construction.
Changed Diffie-Hellman A&B notation to make use of the if construction.

> A & B notation
```
. . .
Alice -> Bob: c = M3<gyx>
Bob {
    let M3<gyx> = c;
    new t: key;
    new f: key;
    let result = if(gxy = gyx, t, f);
}
```
> ProVerif output
```
let Bob() = 
        . . .
	let M3(gyx) = c in
	new t: key;
	new f: key;
	let result = ( if(gxy = gyx) then t else f ) in
	0.
```

