### PR TITLE
Branch refactor

### DIFF
--- a/input/AccountWarrantExecution.sst
+++ b/input/AccountWarrantExecution.sst
@@ -50,7 +50,45 @@ Source -> Public: mpkform = PKIBEFORM<mpk>
 Court -> Public: pkaform = PKFORM<pka>
 Decryptor -> Public: pkcform = PKFORM<pkc>
 Auditor -> Public: pkdform = PKFORM<pkd>
-
+let G = {
+    Court {
+        new r: rand;
+        let ctc = enc(pka, id, r);
+        let signed_ctc = sign(skc, ctc);
+    }
+    Court *->* Auditor: ctcsign = signed_ctc
+    Court {
+        new r2: rand;
+        let audit = enc(pka, encwrap(id, r), r2);
+        let signed_audit = sign(skc, audit);
+        let b = blind(id, r);
+    }
+    Court *->* Decryptor: drequest = <b, pzk(id, r), signed_ctc, signed_audit, pzkenc(id, r)>
+    Decryptor {
+        let <b: bytes, pzk: bytes, signed_ctc: bytes, signed_audit: bytes, pzkenc: bytes> = drequest;
+        let ctc = checksign(signed_ctc, pkc);
+        let audit = checksign(signed_audit, pkc);
+        new p: bytes;
+        let partial = if(checkzkpokenc(ctc, pzkenc) = OK() & checkzkpok(b, pzk) = OK(), pextract(msk, b), p);
+        let dsign = sign(skd, signwrap(audit, ctc, pzkenc));
+    }
+    Decryptor *->* Court: partial = partial
+    Decryptor *->* Auditor: dsign = dsign
+    Court {
+        let sk = bextract(r, partial);
+        let m = decibe(ct, sk);
+        event OkCourt();
+    }
+    Auditor -> Public: auditableproof1 = <ctcsign, dsign>
+    Auditor {
+        let ctc = checksign(ctcsign, pkc);
+        let id_ctc = dec(ska, ctc);
+        let <audit: bytes, ctcd: bytes, zkenc: bytes> = signunwrap(checksign(dsign, pkd));
+        let <id_audit: bytes, r: rand> = encunwrap(dec(ska, audit));
+    }
+    Auditor -> Public: auditableproof2 = <audit, ctcd, zkenc>
+    end
+} in
 Source {
     let ct = encibe(mpk, id, msg);
 }
@@ -58,43 +96,12 @@ Source *->* Court: ct = ct
 Source -> Public: ct = ct
 Court -> Judge {
     Left:
-        branch_end
+        Judge -> Court {
+            Left:
+                G()
+            Right: end
+        }
+        end
     Right: end
 }
-Court {
-    new r: rand;
-    let ctc = enc(pka, id, r);
-    let signed_ctc = sign(skc, ctc);
-}
-Court *->* Auditor: ctcsign = signed_ctc
-Court {
-    new r2: rand;
-    let audit = enc(pka, encwrap(id, r), r2);
-    let signed_audit = sign(skc, audit);
-    let b = blind(id, r);
-}
-Court *->* Decryptor: drequest = <b, pzk(id, r), signed_ctc, signed_audit, pzkenc(id, r)>
-Decryptor {
-    let <b: bytes, pzk: bytes, signed_ctc: bytes, signed_audit: bytes, pzkenc: bytes> = drequest;
-    let ctc = checksign(signed_ctc, pkc);
-    let audit = checksign(signed_audit, pkc);
-    new p: bytes;
-    let partial = if(checkzkpokenc(ctc, pzkenc) = OK() & checkzkpok(b, pzk) = OK(), pextract(msk, b), p);
-    let dsign = sign(skd, signwrap(audit, ctc, pzkenc));
-}
-Decryptor *->* Court: partial = partial
-Decryptor *->* Auditor: dsign = dsign
-Court {
-    let sk = bextract(r, partial);
-    let m = decibe(ct, sk);
-    event OkCourt();
-}
-Auditor -> Public: auditableproof1 = <ctcsign, dsign>
-Auditor {
-    let ctc = checksign(ctcsign, pkc);
-    let id_ctc = dec(ska, ctc);
-    let <audit: bytes, ctcd: bytes, zkenc: bytes> = signunwrap(checksign(dsign, pkd));
-    let <id_audit: bytes, r: rand> = encunwrap(dec(ska, audit));
-}
-Auditor -> Public: auditableproof2 = <audit, ctcd, zkenc>
 end

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -156,8 +156,6 @@ global_type:
   { DefGlobal(name, gt1, gt2) }
 | name = ID; LEFT_PAR; RIGHT_PAR
   { CallGlobal(name) }
-| BRANCH_END
-  { BranchEnd }
 | END
   { GlobalEnd };
 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -148,14 +148,14 @@ channel_option:
 global_type:
 | prin1 = ID; chan = channel_option; prin2 = ID; COLON; x = ID; EQ; t = term; gt = global_type
   { Send(prin1, prin2, chan, x, t, gt ) }
-| prin1 = ID; chan = channel_option; prin2 = ID; LEFT_BRACE; ID; COLON; lb = global_type; ID; COLON; rb = global_type; RIGHT_BRACE; gt = global_type
-  { Branch(prin1, prin2, chan, lb, rb, gt) }
+| prin1 = ID; chan = channel_option; prin2 = ID; LEFT_BRACE; ID; COLON; lb = global_type; ID; COLON; rb = global_type; RIGHT_BRACE;
+  { Branch(prin1, prin2, chan, lb, rb) }
 | prin = ID; LEFT_BRACE; lb = let_bind; RIGHT_BRACE; gt = global_type
   { Compute(prin, lb, gt) }
-| LET; name = ID; LEFT_PAR; params = separated_list(COMMA, param); RIGHT_PAR; EQ; gt1 = global_type; IN; gt2 = global_type
-  { DefGlobal(name, params, gt1, gt2) }
-| name = ID; LEFT_PAR; args = term_list; RIGHT_PAR
-  { CallGlobal(name, args) }
+| LET; name = ID; EQ; LEFT_BRACE; gt1 = global_type; RIGHT_BRACE; IN; gt2 = global_type
+  { DefGlobal(name, gt1, gt2) }
+| name = ID; LEFT_PAR; RIGHT_PAR
+  { CallGlobal(name) }
 | BRANCH_END
   { BranchEnd }
 | END

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -180,14 +180,14 @@ let rec build_channels acc = function
       let channel_name = show_channel (if receiver < sender then receiver ^ sender else sender ^ receiver) opt in
       let parties = (sender, receiver) in
       build_channels ((parties, channel_name)::acc) g
-  | Branch(sender, receiver, opt, lb, rb, g) when opt != Public ->
+  | Branch(sender, receiver, opt, lb, rb) when opt != Public ->
       let channel_name = show_channel (if receiver < sender then receiver ^ sender else sender ^ receiver) opt in
       let parties = (sender, receiver) in
-      build_channels ((parties, channel_name)::(build_channels (build_channels acc lb) rb)) g
-  | Branch(sender, receiver, opt, lb, rb, g) ->
-      build_channels (build_channels (build_channels acc lb) rb) g
+      (parties, channel_name)::(build_channels (build_channels acc lb) rb)
+  | Branch(sender, receiver, opt, lb, rb) ->
+      build_channels (build_channels acc lb) rb
   | Send(_, _, _, _, _, g) | Compute(_, _, g) -> build_channels acc g
-  | DefGlobal(_, _, g, g') -> build_channels (build_channels acc g) g'
+  | DefGlobal(_, g, g') -> build_channels (build_channels acc g) g'
   | BranchEnd -> acc
   | _ -> List.sort_uniq (fun (_, a) (_, b) -> compare a b) acc
 

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -140,7 +140,7 @@ and show_local_type p channels prefix = function
   | LNew (ident, data_type, local_type) -> prefix ^ "new " ^ ident ^ ": " ^ show_dtype data_type ^ ";\n" ^ show_local_type p channels prefix local_type
   | LLet (ident, term, local_type) -> prefix ^ "let " ^ show_pattern ident ^ " = " ^ show_term term ^ " in\n" ^ show_local_type p channels prefix local_type
   | LEvent (ident, termlist, local_type) -> prefix ^ "event " ^ ident ^ "(" ^ show_term_list termlist ^ ");\n" ^ show_local_type p channels prefix local_type
-  | LChoose(_, _, lb, rb, _) | LOffer(_, _, lb, rb, _) ->
+  | LChoose(_, _, lb, rb, _, _) | LOffer(_, _, lb, rb, _, _) ->
       let left = sprintf "%s(\n%s\tlet Left(leftbr) = branchchoice in\n%s\n%s)" prefix prefix (show_local_type p channels (prefix ^ "\t") lb) prefix in
       let right = sprintf "%s(\n%s\tlet Right(rightbr) = branchchoice in\n%s\n%s)" prefix prefix (show_local_type p channels (prefix ^ "\t") rb) prefix in
       sprintf "%sin(c, branchchoice: bitstring);\n%s\n%s|\n%s" prefix left prefix right
@@ -193,19 +193,23 @@ let rec build_channels acc = function
 and build_event_types = function
   (e, args) -> (e, List.map (fun t -> show_dtype t) args)
 
-let rec find_and_print_branch_functions channels l p =
-  match l with
-  | LChoose(_, _, lb, _, next) | LOffer(_, _, lb, _, next) ->
-    let last_local = get_last_local_type lb in
-    begin
-      match last_local with
-      | LCall(name, penv) -> sprintf "%slet %s%s(%s) =\n%s.\n\n" (find_and_print_branch_functions channels next p) p name (String.concat ", " ((show_party_channels p [] ": channel" channels)@(List.map (fun (name, dt) -> name ^ ": " ^ show_dtype dt) penv))) (show_local_type p channels "\t" next)
-      | LChoose(_, _, lb, _, _) | LOffer(_, _, lb, _, _) -> find_and_print_branch_functions channels lb p
-      | _ -> ""
-    end
+let rec find_branch_functions next = function
+  | LChoose(_, _, lb, rb, nextlb, nextrb) | LOffer(_, _, lb, rb, nextlb, nextrb) ->
+    let last_local_lb = get_last_local_type lb in
+    let last_local_rb = get_last_local_type rb in
+    find_branch_functions nextlb last_local_lb @ find_branch_functions nextrb last_local_rb
   | LSend(_, _, _, _, _, next) | LNew (_, _, next) | LLet (_, _, next)
-  | LRecv (_, _, _, _, _, next) | LEvent (_, _, next) -> find_and_print_branch_functions channels next p
-  | LCall(_, _) | LLocalEnd -> ""
+  | LRecv (_, _, _, _, _, next) | LEvent (_, _, next) -> find_branch_functions LLocalEnd next
+  | LCall(name, params) -> find_branch_functions LLocalEnd next@[(name, (params, next))]
+  | LLocalEnd -> []
+
+let rec find_and_print_branch_functions channels l p =
+  let branch_functions = find_branch_functions LLocalEnd l in
+  let bf_uniq = List.rev (List.fold_left (fun acc func -> if List.mem func acc then acc else func::acc) [] branch_functions) in
+  String.concat "" (List.map (
+    fun (name, (params, next)) ->
+      sprintf "let %s%s(%s) =\n%s.\n\n" p name (String.concat ", " ((show_party_channels p [] ": channel" channels)@(List.map (fun (name, dt) -> name ^ ": " ^ show_dtype dt) params))) (show_local_type p channels "\t" next)
+    ) bf_uniq)
 
 let proverif (pr:problem): unit =
   let knowledge = List.map (fun (p, _) -> p, initial_knowledge p [] pr.knowledge) pr.principals in
@@ -215,7 +219,7 @@ let proverif (pr:problem): unit =
   let channels = build_channels [] pr.protocol in
   let channel_inits = String.concat "\n" (List.map (fun (_, a) -> "\tnew " ^ a ^ ": channel;") channels) in
   let global_funs = build_global_funs_list pr.protocol in
-  let locals = List.map (fun (p, _) -> (p, (compile pr.principals [] env pr.formats pr.functions pr.events [] p pr.protocol))) pr.principals in
+  let locals = List.map (fun (p, _) -> (p, (compile pr.principals false env pr.formats pr.functions pr.events [] p pr.protocol))) pr.principals in
   printf  "(* Protocol: %s *)\n\n" pr.name;
   printf "free c: channel.\n\n%s\n\n" "fun Left(bitstring): bitstring [data].\nfun Right(bitstring): bitstring [data].";
   List.iter (fun t -> 

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -200,6 +200,7 @@ let rec find_and_print_branch_functions channels l p =
     begin
       match last_local with
       | LCall(name, penv) -> sprintf "%slet %s%s(%s) =\n%s.\n\n" (find_and_print_branch_functions channels next p) p name (String.concat ", " ((show_party_channels p [] ": channel" channels)@(List.map (fun (name, dt) -> name ^ ": " ^ show_dtype dt) penv))) (show_local_type p channels "\t" next)
+      | LChoose(_, _, lb, _, _) | LOffer(_, _, lb, _, _) -> find_and_print_branch_functions channels lb p
       | _ -> ""
     end
   | LSend(_, _, _, _, _, next) | LNew (_, _, next) | LLet (_, _, next)
@@ -213,8 +214,8 @@ let proverif (pr:problem): unit =
   let event_types = List.map (fun e -> build_event_types e) pr.events in
   let channels = build_channels [] pr.protocol in
   let channel_inits = String.concat "\n" (List.map (fun (_, a) -> "\tnew " ^ a ^ ": channel;") channels) in
-  let global_funs = build_global_funs_list pr.protocol in  
-  let locals = List.map (fun (p, _) -> (p, (compile pr.principals env pr.formats pr.functions pr.events global_funs p pr.protocol))) pr.principals in
+  let global_funs = build_global_funs_list pr.protocol in
+  let locals = List.map (fun (p, _) -> (p, (compile pr.principals [] env pr.formats pr.functions pr.events global_funs p pr.protocol))) pr.principals in
   printf  "(* Protocol: %s *)\n\n" pr.name;
   printf "free c: channel.\n\n%s\n\n" "fun Left(bitstring): bitstring [data].\nfun Right(bitstring): bitstring [data].";
   List.iter (fun t -> 

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -215,7 +215,7 @@ let proverif (pr:problem): unit =
   let channels = build_channels [] pr.protocol in
   let channel_inits = String.concat "\n" (List.map (fun (_, a) -> "\tnew " ^ a ^ ": channel;") channels) in
   let global_funs = build_global_funs_list pr.protocol in
-  let locals = List.map (fun (p, _) -> (p, (compile pr.principals [] env pr.formats pr.functions pr.events global_funs p pr.protocol))) pr.principals in
+  let locals = List.map (fun (p, _) -> (p, (compile pr.principals [] env pr.formats pr.functions pr.events [] p pr.protocol))) pr.principals in
   printf  "(* Protocol: %s *)\n\n" pr.name;
   printf "free c: channel.\n\n%s\n\n" "fun Left(bitstring): bitstring [data].\nfun Right(bitstring): bitstring [data].";
   List.iter (fun t -> 

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -79,8 +79,7 @@ and printBlock tab = function
         | SBranch(_) -> printStatements tab s
         | _ -> printStatements tab s ^ ";"
       ) lst) in
-      ("{\n" ^ tabulate tab) ^ String.sub s 0 ((String.length s) - 1)
-       ^ ("\n" ^ tabulate (tab - 1)  ^ "}")
+      ("{\n" ^ tabulate tab) ^ s ^ ("\n" ^ tabulate (tab - 1)  ^ "}")
 
 and printType = function
     U8 -> "u8"
@@ -130,8 +129,8 @@ and printBranch tab = function
   | Choose(rid, lb, rb) ->
     let id = printrId rid in
     let comment = sprintf "// Need to make a choice on %s. Either %s.sel1() or %s.sel2()\n" id id id in
-    let left = sprintf "%s/*\n%s\n%s*/\n" (tabulate tab) (printStmtList tab lb) (tabulate tab) in
-    let right = sprintf "%s/*\n%s\n%s*/\n" (tabulate tab) (printStmtList tab rb) (tabulate tab) in
+    let left = sprintf "%s/*\n%s;\n%s*/\n" (tabulate tab) (printStmtList tab lb) (tabulate tab) in
+    let right = sprintf "%s/*\n%s;\n%s*/" (tabulate tab) (printStmtList tab rb) (tabulate tab) in
     sprintf "%s%s\n%s" comment left right
 
 and printStatements tab = function

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -76,7 +76,7 @@ and printBlock tab = function
     | BStmts(lst) -> 
       let s = String.concat ("\n" ^ tabulate tab) (List.map (fun s -> 
         match s with 
-        | SBranch(Choose(_, _, _)) -> printStatements tab s
+        | SBranch(_) -> printStatements tab s
         | _ -> printStatements tab s ^ ";"
       ) lst) in
       ("{\n" ^ tabulate tab) ^ String.sub s 0 ((String.length s) - 1)
@@ -123,15 +123,15 @@ and printStmtList tab lst = tabulate tab ^ String.concat (";\n" ^ (tabulate tab)
 and printBranch tab = function
   Offer(rid, lb, rb) -> 
     let id = printrId rid in
-    let mtch = sprintf "let %s = match %s.offer() {\n" id id in
+    let mtch = sprintf "match %s.offer() {\n" id in
     let left = sprintf "%sLeft(%s) => %s,\n" (tabulate (tab+1)) id (printBlock (tab+2) lb) in
     let right = sprintf "%sRight(%s) => %s" (tabulate (tab+1)) id (printBlock (tab+2) rb) in
     sprintf "%s%s%s\n%s}" mtch left right (tabulate (tab))
   | Choose(rid, lb, rb) ->
     let id = printrId rid in
     let comment = sprintf "// Need to make a choice on %s. Either %s.sel1() or %s.sel2()\n" id id id in
-    let left = sprintf "%s/*\n%s;\n%s*/\n" (tabulate tab) (printStmtList tab lb) (tabulate tab) in
-    let right = sprintf "%s/*\n%s;\n%s*/\n" (tabulate tab) (printStmtList tab rb) (tabulate tab) in
+    let left = sprintf "%s/*\n%s\n%s*/\n" (tabulate tab) (printStmtList tab lb) (tabulate tab) in
+    let right = sprintf "%s/*\n%s\n%s*/\n" (tabulate tab) (printStmtList tab rb) (tabulate tab) in
     sprintf "%s%s\n%s" comment left right
 
 and printStatements tab = function

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -123,6 +123,7 @@ and process princ channels is_branch = function
     let lb_bstmts =  BStmts(lb_stmts @ (show_branch_return (SExp(Id(ID("c_" ^ ident)))) lb_stmts)) in
     let rb_bstmts = BStmts(rb_stmts @ (show_branch_return (SExp(Id(ID("c_" ^ ident)))) rb_stmts)) in
     SBranch(Offer(ID("c_" ^ ident), lb_bstmts, rb_bstmts))::process princ channels is_branch local_type
+  | LCall(name, env) -> [SExp(toFunction (princ ^ name) (Exps(List.map (fun (x, _) -> Id(ID(x))) env)))]
   | LLocalEnd when is_branch -> [SExp(Id(ID("process::exit(1)")))]
   | LLocalEnd -> close_channels channels
   | _ -> [End]

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -110,12 +110,12 @@ and process princ channels is_branch = function
     let ident = get_channel_name princ sender receiver in
     SDeclExp(DeclExp((ID("(c_" ^ ident ^ ", " ^ x ^ ")")), toFunction ("recv") (Id(ID("c_" ^ ident)))))::process princ channels is_branch local_type
   | LEvent (ident, term, local_type) -> process princ channels is_branch local_type
-  | LChoose(sender, receiver, lb, rb, penv, local_type) -> 
+  | LChoose(sender, receiver, lb, rb, local_type) -> 
     let ident = get_channel_name princ sender receiver in
     let sel1 = SDeclExp(DeclExp((ID("c_" ^ ident)), Id(ID("c_" ^ ident ^ ".sel1()")))) in
     let sel2 = SDeclExp(DeclExp((ID("c_" ^ ident)), Id(ID("c_" ^ ident ^ ".sel2()")))) in
     SBranch(Choose(ID("c_" ^ ident), sel1::process princ channels true lb, sel2::process princ channels true rb))::process princ channels is_branch local_type
-  | LOffer(sender, receiver, lb, rb, penv, local_type) -> 
+  | LOffer(sender, receiver, lb, rb, local_type) -> 
     let ident = get_channel_name princ sender receiver in
     let branch_channel = List.filter (fun (s, r) -> sender = s && receiver = r) channels in
     let lb_stmts = process princ branch_channel true lb in
@@ -124,7 +124,6 @@ and process princ channels is_branch = function
     let rb_bstmts = BStmts(rb_stmts @ (show_branch_return (SExp(Id(ID("c_" ^ ident)))) rb_stmts)) in
     SBranch(Offer(ID("c_" ^ ident), lb_bstmts, rb_bstmts))::process princ channels is_branch local_type
   | LLocalEnd when is_branch -> [SExp(Id(ID("process::exit(1)")))]
-  | LBranchEnd -> []
   | LLocalEnd -> close_channels channels
   | _ -> [End]
 

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -45,12 +45,14 @@ and rust_a_types type_list =
   String.concat "\n" (types)
 
 and channels acc = function
-  Send(sender, receiver, _, _, _, g) | Branch(sender, receiver, _, _, _, g) when List.exists (fun (a, b) -> sender = a && receiver = b) acc ->
+  Send(sender, receiver, _, _, _, g) when List.exists (fun (a, b) -> sender = a && receiver = b) acc ->
     channels acc g
-  | Send(sender, receiver, _, _, _, g) | Branch(sender, receiver, _, _, _, g) ->
-    channels ([(receiver, sender);(sender, receiver)]@acc) g
+  | Send(sender, receiver, _, _, _, g) ->
+    channels ([(receiver, sender); (sender, receiver)]@acc) g
   | Compute(_, _, g) -> channels acc g
-  | DefGlobal(_, _, g, g') -> channels (channels acc g) g'
+  | DefGlobal(_, g, g') -> channels (channels acc g) g'
+  | Branch(sender, receiver, _, _, _) when not (List.exists (fun (a, b) -> sender = a && receiver = b) acc) ->
+    [(receiver, sender); (sender, receiver)]@acc
   | _ -> acc
 
 and principal_channels principal channels = 


### PR DESCRIPTION
## Details
- Refactor branching so we define global functions with global calls in SST;
  - Support for global functions and global calls;
- Made sure type checking works with a branch;
  - Additional check that both branches translate to the same for the rest of the parties that are not participating in a branch;  
- We no longer support global type after a branch;
- AWE.SST has been updated to support the new syntax.