### PR TITLE
Support for If blocks

### DIFF
--- a/input/NeedhamSchroeder.sst
+++ b/input/NeedhamSchroeder.sst
@@ -1,0 +1,61 @@
+Problem: NeedhamSchroeder;
+Principals: A, B;
+Knowledge: ska:skey@A,
+           skb:skey@B,
+           pkb:pkey@A = pk(skb),
+           pka:pkey@B = pk(ska);
+Types: bytes, symkey, skey, pkey;
+Functions: pk(skey) -> pkey,
+           aenc(pkey, bytes) -> bytes,
+           adec(skey, bytes) -> bytes,
+           hash(bytes) -> bytes,
+           nawrap(pkey, bytes) -> bytes,
+           naunwrap(bytes) -> <pkey, bytes>,
+           nanbwrap(pkey, bytes, bytes) -> bytes,
+           nanbunwrap(bytes) -> <pkey, bytes, bytes>; 
+Equations: adec(k, aenc(pk(k), m)) = m,
+           naunwrap(nawrap(pk, nonce)) = <pk, nonce>,
+           nanbunwrap(nanbwrap(pk, nonce1, nonce2)) = <pk, nonce1, nonce2>;
+Events: start_a(pkey, pkey, bytes),
+        mid_a(pkey, pkey, bytes, bytes), 
+        end_a(pkey, pkey, bytes, bytes),
+        start_b(pkey, pkey, bytes, bytes),
+        end_b(pkey, pkey, bytes, bytes);
+Queries: event(start_a(pka, pkb, na)),
+         event(mid_a(pka, pkb, na, nb)),
+         event(end_a(pka, pkb, na, nb)),
+         event(start_b(pka, pkb, na, nb)),
+         event(end_b(pka, pkb, na, nb)),
+         event(end_a(pka, pkb, na, nb)) => event(start_b(pka, pkb, na, nb)),
+         inj-event(end_a(pka, pkb, na, nb)) => inj-event(start_b(pka, pkb, na, nb));
+Protocol:
+A {
+    new na: bytes;
+    event start_a(pk(ska), pkb, na);
+    let ct = aenc(pkb, nawrap(pk(ska), na));
+}
+A -> B: cta = ct
+B {
+    let <%pka, na: bytes> = naunwrap(adec(skb, cta));
+    new nb: bytes;
+    event start_b(pka, pk(skb), na, nb);
+    let ct = aenc(pka, nanbwrap(pk(skb), na, nb));
+}
+B -> A: ctb = ct
+A {
+    let <%pkb, x_na: bytes, x_nb: bytes> = nanbunwrap(adec(ska, ctb));
+    event mid_a(pk(ska), pkb, x_na, x_nb);
+    new enc_nb: bytes;
+    if (x_na = na) {
+        let enc_nb = aenc(pkb, x_nb);
+        event end_a(pk(ska), pkb, x_na, x_nb);
+    }
+}
+A -> B: z = enc_nb
+B {
+    let z_nb = adec(skb, z);
+    if (z_nb = nb) {
+        event end_b(pka, pk(skb), na, nb);
+    }
+}
+end

--- a/output/CompiledNS.pv
+++ b/output/CompiledNS.pv
@@ -1,0 +1,91 @@
+(* Protocol: NeedhamSchroeder *)
+
+free c: channel.
+
+fun Left(bitstring): bitstring [data].
+fun Right(bitstring): bitstring [data].
+
+type bytes.
+type symkey.
+type skey.
+type pkey.
+
+fun pk(skey): pkey.
+fun aenc(pkey, bytes): bytes.
+fun adec(skey, bytes): bytes.
+fun hash(bytes): bytes.
+fun nawrap(pkey, bytes): bytes.
+fun naunwrap(bytes): bitstring.
+fun nanbwrap(pkey, bytes, bytes): bytes.
+fun nanbunwrap(bytes): bitstring.
+
+equation forall k: skey, m: bytes;
+	adec(k, aenc(pk(k), m)) = m.
+equation forall nonce: bytes, pk: pkey;
+	naunwrap(nawrap(pk, nonce)) = (pk, nonce).
+equation forall nonce1: bytes, nonce2: bytes, pk: pkey;
+	nanbunwrap(nanbwrap(pk, nonce1, nonce2)) = (pk, nonce1, nonce2).
+
+event start_a(pkey, pkey, bytes).
+event mid_a(pkey, pkey, bytes, bytes).
+event end_a(pkey, pkey, bytes, bytes).
+event start_b(pkey, pkey, bytes, bytes).
+event end_b(pkey, pkey, bytes, bytes).
+
+query na: bytes, pka: pkey, pkb: pkey;
+	event(start_a(pka, pkb, na)).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	event(mid_a(pka, pkb, na, nb)).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	event(end_a(pka, pkb, na, nb)).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	event(start_b(pka, pkb, na, nb)).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	event(end_b(pka, pkb, na, nb)).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	(event(end_a(pka, pkb, na, nb)) ==> event(start_b(pka, pkb, na, nb))).
+query na: bytes, nb: bytes, pka: pkey, pkb: pkey;
+	(inj-event(end_a(pka, pkb, na, nb)) ==> inj-event(start_b(pka, pkb, na, nb))).
+
+let AI(enc_nb: bytes) =
+	out(c, enc_nb);
+	0.
+
+let A(pkb: pkey, ska: skey) = 
+	new na: bytes;
+	event start_a(pk(ska), pkb, na);
+	let ct = aenc(pkb, nawrap(pk(ska), na)) in
+	out(c, ct);
+	in(c, ctb: bytes);
+	let (=pkb, x_na: bytes, x_nb: bytes) = nanbunwrap(adec(ska, ctb)) in
+	event mid_a(pk(ska), pkb, x_na, x_nb);
+	new enc_nb: bytes;
+	if x_na = na then
+		let enc_nb = aenc(pkb, x_nb) in
+		event end_a(pk(ska), pkb, x_na, x_nb);
+		AI(enc_nb)
+	else
+		AI(enc_nb).
+
+let B(pka: pkey, skb: skey) = 
+	in(c, cta: bytes);
+	let (=pka, na: bytes) = naunwrap(adec(skb, cta)) in
+	new nb: bytes;
+	event start_b(pka, pk(skb), na, nb);
+	let ct = aenc(pka, nanbwrap(pk(skb), na, nb)) in
+	out(c, ct);
+	in(c, z: bytes);
+	let z_nb = adec(skb, z) in
+	if z_nb = nb then
+		event end_b(pka, pk(skb), na, nb);
+		0.
+
+process (
+	new ska: skey;
+	new skb: skey;
+	let pkb = pk(skb) in
+	let pka = pk(ska) in
+
+	A(pkb, ska) |
+	B(pka, skb)
+)

--- a/output/CompiledNS.rs
+++ b/output/CompiledNS.rs
@@ -1,0 +1,145 @@
+extern crate session_types;
+use session_types::*;
+use std::{marker};
+use serde::{Serialize, Deserialize};
+use std::thread;
+use std::process;
+use std::borrow::Borrow;
+use std::marker::PhantomData;
+use serde::de::DeserializeOwned;
+
+#[derive(Serialize, Deserialize)]
+pub struct Repr<T>(Vec<u8>, PhantomData<T>);
+
+impl<T : Serialize + DeserializeOwned> Represent<T> for Repr<T> {
+    fn from_repr(b: Repr<T>) -> T { bincode::deserialize(&b.0[..]).unwrap() }
+    fn to_repr(b: T) -> Repr<T> { Repr(bincode::serialize(&b).unwrap(), PhantomData) }
+}
+
+trait Represent<T> {
+    fn from_repr(_: Repr<T>) -> T;
+    fn to_repr(_: T) -> Repr<T>;
+}
+
+fn send<E, P, A: marker::Send + Serialize + DeserializeOwned + 'static>(c: Chan<E, Send<Repr<A>, P>>, v: A) -> Chan<E, P> { c.send(Repr::to_repr(v)) }
+fn recv<E, P, A: marker::Send + Serialize + DeserializeOwned + 'static>(c: Chan<E, Recv<Repr<A>, P>>) -> (Chan<E, P>, A) { let (c, x) = c.recv(); (c, Repr::from_repr(x)) }
+fn close<E>(c: Chan<E, Eps>) { c.close() }
+
+type AB = Send<Repr<bytes>, Recv<Repr<bytes>, Send<Repr<bytes>, Eps>>>;
+
+type BA = Recv<Repr<bytes>, Send<Repr<bytes>, Recv<Repr<bytes>, Eps>>>;
+
+type bytes = /* unimplemented */;
+type symkey = /* unimplemented */;
+type skey = /* unimplemented */;
+type pkey = /* unimplemented */;
+
+fn pk(a1: skey) -> pkey {
+	unimplemented!();
+}
+fn aenc(a1: pkey, a2: bytes) -> bytes {
+	unimplemented!();
+}
+fn adec(a1: skey, a2: bytes) -> bytes {
+	unimplemented!();
+}
+fn hash(a1: bytes) -> bytes {
+	unimplemented!();
+}
+fn nawrap(a1: pkey, a2: bytes) -> bytes {
+	unimplemented!();
+}
+fn naunwrap(a1: bytes) -> (pkey, bytes) {
+	unimplemented!();
+}
+fn nanbwrap(a1: pkey, a2: bytes, a3: bytes) -> bytes {
+	unimplemented!();
+}
+fn nanbunwrap(a1: bytes) -> (pkey, bytes, bytes) {
+	unimplemented!();
+}
+fn fresh_bytes() -> bytes {
+	unimplemented!();
+}
+fn fresh_symkey() -> symkey {
+	unimplemented!();
+}
+fn fresh_skey() -> skey {
+	unimplemented!();
+}
+fn fresh_pkey() -> pkey {
+	unimplemented!();
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	#[test]
+	fn test_equation_0() {
+		let k = fresh_skey();
+		let m = fresh_bytes();
+		assert_eq!(adec(k, aenc(pk(k), m)), m);
+	}
+	#[test]
+	fn test_equation_1() {
+		let nonce = fresh_bytes();
+		let pk = fresh_pkey();
+		assert_eq!(naunwrap(nawrap(pk, nonce)), (pk, nonce));
+	}
+	#[test]
+	fn test_equation_2() {
+		let nonce1 = fresh_bytes();
+		let nonce2 = fresh_bytes();
+		let pk = fresh_pkey();
+		assert_eq!(nanbunwrap(nanbwrap(pk, nonce1, nonce2)), (pk, nonce1, nonce2));
+	}
+}
+
+fn a(c_AB: Chan<(), AB>, pkb: pkey, ska: skey) {
+	let na = fresh_bytes();
+	let ct = aenc(pkb, nawrap(pk(ska), na));
+	let c_AB = send(c_AB, ct);
+	let (c_AB, ctb) = recv(c_AB);
+	let (v0, x_na, x_nb) = nanbunwrap(adec(ska, ctb));
+	if pkb == v0 {
+		let enc_nb = fresh_bytes();
+		if x_na == na {
+			let enc_nb = aenc(pkb, x_nb);
+			let c_AB = send(c_AB, enc_nb);
+			close(c_AB);
+		} else {
+			let c_AB = send(c_AB, enc_nb);
+			close(c_AB);
+		};
+	};
+}
+
+fn b(c_BA: Chan<(), BA>, pka: pkey, skb: skey) {
+	let (c_BA, cta) = recv(c_BA);
+	let (v1, na) = naunwrap(adec(skb, cta));
+	if pka == v1 {
+		let nb = fresh_bytes();
+		let ct = aenc(pka, nanbwrap(pk(skb), na, nb));
+		let c_BA = send(c_BA, ct);
+		let (c_BA, z) = recv(c_BA);
+		let z_nb = adec(skb, z);
+		if z_nb == nb {
+			close(c_BA);
+		} else {
+			close(c_BA);
+		};
+	};
+}
+
+fn main() {
+	let ska = fresh_skey();
+	let skb = fresh_skey();
+	let pkb = pk(skb);
+	let pka = pk(ska);
+
+	let (c_AB, c_BA) = session_channel();
+
+	let a_t = thread::spawn(move || a(c_AB, ska, pkb));
+	let b_t = thread::spawn(move || b(c_BA, skb, pka));
+	let _ = (a_t.join(), b_t.join());
+}

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -50,7 +50,7 @@ rule read =
   | "in"     { IN }
   | "end"    { END }
   | "if"     { IF }
-  | "branch_end" { BRANCH_END }
+  | "else"   { ELSE }
   | "dishonest"  { DISHONEST }
   | "Problem"    { PROBLEM }
   | "Principals" { PRINCIPALS }

--- a/src/main.ml
+++ b/src/main.ml
@@ -20,12 +20,6 @@ let parse_with_error lexbuf =
     fprintf stderr "%a: syntax error\n" print_position lexbuf;
     exit (-1)
 
-let rec print_errors = function
-  | (msg, g)::err ->
-    fprintf stderr "%s in %s\n" msg (show_global_type_nr g);
-    print_errors err
-  | [] -> ()
-
 let main =
   let filename = Sys.argv.(1) in
   let inx = open_in filename in

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -162,6 +162,3 @@ global_type:
   { CallGlobal(name) }
 | END
   { GlobalEnd };
-
-param:
-| x = ID; COLON; dt = data_type; AT; p = ID { ((x, dt), p) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -6,7 +6,7 @@
 %token COMMA COLON SEMI PCT ARROW BIGARROW AT AUTH CONF AUTHCONF
 %token LEFT_PAR RIGHT_PAR LEFT_ANGLE RIGHT_ANGLE LEFT_BRACE RIGHT_BRACE LEFT_BRACK RIGHT_BRACK
 %token EQ AND OR NOT
-%token NEW LET EVENT INJ_EVENT IN END IF BRANCH_END
+%token NEW LET EVENT INJ_EVENT IN END IF ELSE
 %token PROBLEM PRINCIPALS KNOWLEDGE TYPES FUNCTIONS EQUATIONS FORMATS EVENTS QUERIES PROTOCOL DISHONEST
 %token EOF
 
@@ -97,7 +97,7 @@ term:
 | LEFT_PAR; t = term; RIGHT_PAR
   { t }
 | IF; LEFT_PAR; cond = term; COMMA; tterm = term; COMMA; fterm = term; RIGHT_PAR
-  { If(cond, tterm, fterm) };
+  { IfAssign(cond, tterm, fterm) };
 
 term_list:
 | l = separated_list(COMMA, term)
@@ -137,6 +137,8 @@ let_bind:
   { Let(p, t, letb) }
 | EVENT; name = ID; LEFT_PAR; ts = term_list; RIGHT_PAR; SEMI; letb = let_bind
   { Event(name, ts, letb) }
+| IF; LEFT_PAR; cond = term; RIGHT_PAR; LEFT_BRACE; then_body = let_bind; RIGHT_BRACE; ELSE; LEFT_BRACE; else_body = let_bind; RIGHT_BRACE
+  { IfBlock(cond, then_body, else_body) }
 | { LetEnd };
 
 channel_option:

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -116,7 +116,7 @@ pattern:
 | LEFT_PAR; p = pattern; RIGHT_PAR 
   { p }
 | name = ID
-  { PVar(name, None) }
+  { PVar(name, DNone) }
 | name = ID; COLON; dt = data_type
   { PVar(name, dt) }
 | PCT; t = term
@@ -139,6 +139,8 @@ let_bind:
   { Event(name, ts, letb) }
 | IF; LEFT_PAR; cond = term; RIGHT_PAR; LEFT_BRACE; then_body = let_bind; RIGHT_BRACE; ELSE; LEFT_BRACE; else_body = let_bind; RIGHT_BRACE
   { IfBlock(cond, then_body, else_body) }
+| IF; LEFT_PAR; cond = term; RIGHT_PAR; LEFT_BRACE; then_body = let_bind; RIGHT_BRACE
+  { IfBlock(cond, then_body, LetEnd) }
 | { LetEnd };
 
 channel_option:

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -57,14 +57,17 @@ evdef:
 | e = ID; LEFT_PAR; params = data_type_list; RIGHT_PAR { (e, params) }
 
 qdef:
+| events = event_list; BIGARROW; q = qdef { CorrQuery(events, q) }
 | event = event { ReachQuery(event) }
-| event = event; BIGARROW; q = qdef { CorrQuery(event, q) }
 
 event:
 | INJ_EVENT; LEFT_PAR; e = ID; LEFT_PAR; args = term_list; RIGHT_PAR; RIGHT_PAR;
   { InjEvent(e, args) }
 | EVENT; LEFT_PAR; e = ID; LEFT_PAR; args = term_list; RIGHT_PAR; RIGHT_PAR;
   { NonInjEvent(e, args) }
+
+event_list:
+| l = separated_list(AND, event) { l }
 
 prindef:
 | name = ID; LEFT_BRACK; DISHONEST; RIGHT_BRACK

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -223,7 +223,6 @@ let proverif (pr:problem): unit =
   let event_types = List.map (fun e -> build_event_types e) pr.events in
   let channels = build_channels [] pr.protocol in
   let channel_inits = String.concat "\n" (List.map (fun (_, a) -> "\tnew " ^ a ^ ": channel;") channels) in
-  let global_funs = build_global_funs_list pr.protocol in
   let locals = List.map (fun (p, _) -> (p, (compile pr.principals "" [] env pr.formats pr.functions pr.events [] p pr.protocol))) pr.principals in
   printf  "(* Protocol: %s *)\n\n" pr.name;
   printf "free c: channel.\n\n%s\n\n" "fun Left(bitstring): bitstring [data].\nfun Right(bitstring): bitstring [data].";

--- a/src/proverif.ml
+++ b/src/proverif.ml
@@ -58,9 +58,11 @@ and show_event = function
   NonInjEvent(id, args) -> "event(" ^ id ^ "(" ^ show_term_list args ^ "))"
   | InjEvent(id, args) -> "inj-event(" ^ id ^ "(" ^ show_term_list args ^ "))"
 
+and show_events evs = String.concat " && " (List.map (fun e -> show_event e) evs)
+
 let rec show_query = function
   ReachQuery(event) -> show_event event
-  | CorrQuery(event, next) -> "(" ^ show_event event ^ " ==> " ^ show_query next ^ ")"
+  | CorrQuery(events, next) -> "(" ^ show_events events ^ " ==> " ^ show_query next ^ ")"
 
 let rec build_query_params query funcs event_names_and_types function_names_and_types = (* [(var name, type)...] *)
   let rec inner e t pos function_types =
@@ -89,7 +91,7 @@ let rec build_query_params query funcs event_names_and_types function_names_and_
     | _ -> [] in
   let params = 
     match query with
-    | ReachQuery(event) -> 
+    | ReachQuery(event) ->
       begin
         match event with
         | NonInjEvent(e, args) | InjEvent(e, args) -> 
@@ -97,14 +99,15 @@ let rec build_query_params query funcs event_names_and_types function_names_and_
           if List.length args <> List.length event_types then raise (SyntaxError(sprintf "Wrong number of arguments passed to %s event" e));
           List.flatten (List.mapi (fun i arg -> inner e arg i []) args)
       end
-    | CorrQuery(event, next) ->
+    | CorrQuery(events, next) ->
+      (List.flatten (List.map (fun event -> 
       begin
         match event with
         | NonInjEvent(e, args) | InjEvent(e, args) -> 
           let event_types = List.assoc e event_names_and_types in
           if List.length args <> List.length event_types then raise (SyntaxError(sprintf "Wrong number of arguments passed to %s event" e));
           List.flatten (List.mapi (fun i arg -> inner e arg i []) args)
-      end
+      end) events))
       @ build_query_params next funcs event_names_and_types function_names_and_types in
   List.sort_uniq (fun (a, _) (c, _) -> compare a c) params
 
@@ -118,7 +121,7 @@ and show_query_params query funcs event_names_and_types function_names_and_types
 and show_query_with_params query funcs event_names_and_types function_names_and_types =
   match query with
   | ReachQuery(event) -> "query " ^ (show_query_params query funcs event_names_and_types function_names_and_types) ^ show_event event
-  | CorrQuery(event, next) -> "query " ^ (show_query_params query funcs event_names_and_types function_names_and_types) ^ show_query query
+  | CorrQuery(_, _) -> "query " ^ (show_query_params query funcs event_names_and_types function_names_and_types) ^ show_query query
 
 and show_channel parties = function
   Public -> "c"

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -116,8 +116,8 @@ and printFunctions funs = String.concat "\n" (List.map (fun f-> printFunction f)
 
 and printIf tab ifst =
   match ifst with
-  | If(cond, thenb, Empty) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb
-  | If(cond, thenb, elseb) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb ^ " else " ^ printBlock (tab+1) elseb
+  | If(cond, thenb, Empty) -> "if (" ^ printExp tab cond ^ ") " ^ printBlock (tab+1) thenb
+  | If(cond, thenb, elseb) -> "if (" ^ printExp tab cond ^ ") " ^ printBlock (tab+1) thenb ^ " else " ^ printBlock (tab+1) elseb
 
 and printStmtList tab lst = tabulate tab ^ String.concat (";\n" ^ (tabulate tab)) (List.map (fun s -> printStatements tab s) lst)
 

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -116,8 +116,8 @@ and printFunctions funs = String.concat "\n" (List.map (fun f-> printFunction f)
 
 and printIf tab ifst =
   match ifst with
-  | If(cond, thenb, Empty) -> "if (" ^ printExp tab cond ^ ") " ^ printBlock (tab+1) thenb
-  | If(cond, thenb, elseb) -> "if (" ^ printExp tab cond ^ ") " ^ printBlock (tab+1) thenb ^ " else " ^ printBlock (tab+1) elseb
+  | If(cond, thenb, Empty) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb
+  | If(cond, thenb, elseb) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb ^ " else " ^ printBlock (tab+1) elseb
 
 and printStmtList tab lst = tabulate tab ^ String.concat (";\n" ^ (tabulate tab)) (List.map (fun s -> printStatements tab s) lst)
 

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -63,7 +63,7 @@ and printExp tab = function
     | OExp(exp, Equals, exp2) -> printExp tab exp ^ " == " ^  printExp tab exp2
     | OExp(exp, And, exp2) -> printExp tab exp ^ " && " ^ printExp tab exp2
     | OExp(exp, Or, exp2) -> printExp tab exp ^ " || " ^ printExp tab exp2
-    | IfAssign(cond, block1, block2) -> sprintf "if %s %s else %s" (printExp tab cond) (printBlock (tab+1) block1) (printBlock (tab+1) block2)
+    | If(cond, block1, block2) -> sprintf "if %s %s else %s" (printExp tab cond) (printBlock (tab+1) block1) (printBlock (tab+1) block2)
     | Unimplemented -> "unimplemented!()"
 
 and printSDeclExp tab = function

--- a/src/rustprinter.ml
+++ b/src/rustprinter.ml
@@ -114,8 +114,10 @@ and printFunction = function
 
 and printFunctions funs = String.concat "\n" (List.map (fun f-> printFunction f) funs)
 
-and printIf tab st block =
-  "if " ^ printExp tab st  ^ " " ^ printBlock (tab+1) block
+and printIf tab ifst =
+  match ifst with
+  | If(cond, thenb, Empty) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb
+  | If(cond, thenb, elseb) -> "if " ^ printExp tab cond ^ " " ^ printBlock (tab+1) thenb ^ " else " ^ printBlock (tab+1) elseb
 
 and printStmtList tab lst = tabulate tab ^ String.concat (";\n" ^ (tabulate tab)) (List.map (fun s -> printStatements tab s) lst)
 
@@ -138,6 +140,6 @@ and printStatements tab = function
     | SBlock(block) -> printBlock tab block
     | SExp(exp) -> printExp tab exp
     | SFunction(rFunction) -> printFunction rFunction
-    | SIfStatement(If(st, block)) -> printIf tab st block
+    | SIfStatement(ifStatement) -> printIf tab ifStatement
     | SBranch(branch) -> printBranch tab branch
     | End -> ""

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -92,16 +92,16 @@ and process princ channels = function
     let pats = List.map (fun x-> fst(x)) patterns in
     let strPtn = StructPattern(ID(fname), pats) in
     if(conditions = []) then SDeclExp(PatrExp(strPtn, translateTerm term))::process princ channels local_type
-    else SDeclExp(PatrExp(strPtn, translateTerm term))::[SIfStatement(If((equals_condition_patterns conditions), BStmts(process princ channels local_type)))]
+    else SDeclExp(PatrExp(strPtn, translateTerm term))::[SIfStatement(If((equals_condition_patterns conditions), BStmts(process princ channels local_type), Empty))]
   | LLet (PMatch(mat), term, local_type) ->
-    [SIfStatement(If(OExp(translateTerm mat, Equals, translateTerm term), BStmts(process princ channels local_type)))]
+    [SIfStatement(If(OExp(translateTerm mat, Equals, translateTerm term), BStmts(process princ channels local_type), Empty))]
   | LLet (ident, term, local_type) ->
     let patterns = translatePattern ident [] in
     let conditions = snd(patterns) in
     if(conditions = []) then begin
       SDeclExp(DeclExp(fst(patterns), translateTerm term))::process princ channels local_type end
     else begin
-      [SIfStatement(If((equals_condition_patterns conditions), BStmts(process princ channels local_type)))]
+      [SIfStatement(If((equals_condition_patterns conditions), BStmts(process princ channels local_type), Empty))]
     end
   | LRecv (sender, receiver, opt, PVar(x, _), term, LLet (PForm(fname, args), Var(xx), local_type)) ->
     let ident = get_channel_name princ sender receiver in
@@ -122,6 +122,8 @@ and process princ channels = function
     let lb_bstmts = BStmts(lb_stmts) in
     let rb_bstmts = BStmts(rb_stmts) in
     [SBranch(Offer(ID("c_" ^ ident), lb_bstmts, rb_bstmts))]
+  | LIf(cond, thenb, elseb) ->
+    [SIfStatement(If(translateTerm cond, BStmts(process princ channels thenb), BStmts(process princ channels elseb)))]
   | LLocalEnd -> close_channels channels
   | LCall(_, _, local_type) -> process princ channels local_type (* Compiling from Local Types to Rust Types *)
   | _ -> [End]

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -20,7 +20,7 @@ let rec translateTerm t =
   | And(l, r) -> OExp(translateTerm l, And, translateTerm r)
   | Or(l, r) -> OExp(translateTerm l, Or, translateTerm r)
   | Not(t) -> Id(ID("!" ^ printExp 0 (translateTerm t)))
-  | If(cond, t1, t2) -> IfAssign(translateTerm cond, BStmts([SExp(translateTerm t1)]), BStmts([SExp(translateTerm t2)]))
+  | IfAssign(cond, t1, t2) -> If(translateTerm cond, BStmts([SExp(translateTerm t1)]), BStmts([SExp(translateTerm t2)]))
   | Null -> Id(ID(""))
 
 and combineConditions cons =

--- a/src/rusttranslator.ml
+++ b/src/rusttranslator.ml
@@ -84,7 +84,7 @@ and process princ channels = function
     LSend(sender, receiver, opt, t, _, local_type) ->
     let ident = get_channel_name princ sender receiver in
     let send = toFunction "send" (Exps([Id(ID("c_" ^ ident)); translateTerm t])) in
-    SDeclExp(DeclExp(fst(translatePattern (PVar ("c_" ^ ident, None)) []), send))::process princ channels local_type
+    SDeclExp(DeclExp(fst(translatePattern (PVar ("c_" ^ ident, DNone)) []), send))::process princ channels local_type
   | LNew (ident, data_type, local_type) -> (fresh ident data_type)::process princ channels local_type
   | LLet (PForm(fname, args), term, local_type) ->
     let patterns = List.map (fun a -> translatePattern (a) []) args in

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -136,7 +136,7 @@ let rust_output (pr:problem) : unit =
   printf "%s\n" (rust_handwritten);
   let channel_pairs = channels [] pr.protocol in
   let global_funs = build_global_funs_list pr.protocol in
-  let principal_locals = List.map (fun (p, _) -> (p, (compile pr.principals [] env pr.formats pr.functions pr.events global_funs p pr.protocol))) pr.principals in
+  let principal_locals = List.map (fun (p, _) -> (p, (compile pr.principals "" [] env pr.formats pr.functions pr.events global_funs p pr.protocol))) pr.principals in
   List.iter (fun (p, _) -> 
       printf "%s\n" (output_principal_channels (List.assoc p principal_locals))) pr.principals;
   let abstract_types = List.filter_map (function DAType(s1,s2) -> Some(DAType(s1,s2)) | _ -> None) pr.types in

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -20,7 +20,7 @@ and show_term = function
   | And(t1, t2) -> show_term t1 ^ " & " ^ show_term t2
   | Or(t1, t2) -> show_term t1 ^ " | " ^ show_term t2
   | Not(t) -> "~" ^ show_term t
-  | Null | If(_,_,_) -> ""
+  | Null | IfAssign(_,_,_) -> ""
 
 and show_format name = name ^ enum_func
 

--- a/src/rusttypes.ml
+++ b/src/rusttypes.ml
@@ -89,7 +89,8 @@ let output_principal_channels principal_locals =
     | LOffer(sender, receiver, lb, rb) when sender = s && receiver = r ->
       "Offer<" ^ build_channel lb s r continue ^ ", " ^ build_channel rb s r continue ^ ">"
     | LSend(_, _, _, _, _, local_type) | LRecv(_, _, _, _, _, local_type) | LNew(_, _, local_type) |
-        LLet(_, _, local_type) | LEvent(_, _, local_type) | LOffer(_, _, local_type, _) | LChoose(_, _, local_type, _) | LCall(_, _, local_type) -> (* For non-branching principles, so used to pick either local_type_lb or local_type_rb for LChoose and LOffer (they will be the same), now we are just passing next *)
+      LLet(_, _, local_type) | LEvent(_, _, local_type) | LOffer(_, _, local_type, _) | 
+      LChoose(_, _, local_type, _) | LCall(_, _, local_type) | LIf(_, local_type, _) -> (* For non-branching principles, so used to pick either local_type_lb or local_type_rb for LChoose and LOffer (they will be the same), now we are just passing next *)
       build_channel local_type s r continue
     | LLocalEnd -> "Eps" in
   let rec inner local_types channels = 
@@ -106,7 +107,7 @@ let output_principal_channels principal_locals =
         | Some(_) -> inner local_type_rb (inner local_type_lb channels)
         | None -> inner local_type_rb (inner local_type_lb ((sender ^ receiver, build_channel local_types sender receiver "") :: channels))
       end
-    | LNew(_, _, local_type) | LLet(_, _, local_type) | LEvent(_, _, local_type) | LCall(_, _, local_type) ->
+    | LNew(_, _, local_type) | LLet(_, _, local_type) | LEvent(_, _, local_type) | LCall(_, _, local_type) | LIf(_, local_type, _) ->
       inner local_type channels
     | LLocalEnd -> channels in
   List.fold_left (fun acc (channel_name, channel) -> acc ^ (sprintf "type %s = %s;\n" channel_name channel)) "" (inner principal_locals [])

--- a/src/rusttypes2.ml
+++ b/src/rusttypes2.ml
@@ -45,7 +45,7 @@ and exp =
   | EStruct of rId * structValues
   | Exp of exp * exp
   | OExp of exp * op * exp
-  | IfAssign of exp * block * block
+  | If of exp * block * block
   | Unimplemented
 
 and ifStatement =

--- a/src/rusttypes2.ml
+++ b/src/rusttypes2.ml
@@ -49,7 +49,7 @@ and exp =
   | Unimplemented
 
 and ifStatement =
-  | If of exp * block
+  | If of exp * block * block
 
 and branchStatement =
   | Offer of rId * block * block

--- a/src/types.ml
+++ b/src/types.ml
@@ -65,7 +65,7 @@ type event =
   
 type query =
   ReachQuery of event
-  | CorrQuery of event * query
+  | CorrQuery of event list * query
 
 (* Global types: p -> q *)
 type global_type =

--- a/src/types.ml
+++ b/src/types.ml
@@ -150,40 +150,11 @@ and show_dtype t =
   | DFType dtype -> dtype
   | _ -> ""
 
-and show_let_bind = function
-    New(name, data_type, letb) -> "  " ^ "new " ^ name ^ ";\n" ^ show_let_bind letb
-  | Let(p, t, letb) -> "let " ^ show_pattern p ^ " = " ^ show_term t ^ " in\n" ^ show_let_bind letb
-  | Event(f, args, letb) -> "event " ^ f ^ "("^ show_term_list args ^ ")\n" ^ show_let_bind letb
-  | LetEnd -> ""
-
 and show_channel_option = function
     Public   -> " -> "
   | Auth     -> " *-> "
   | Conf     -> " ->* "
   | AuthConf -> " *->* "
-
-(* Show global types *)
-and show_global_type = function
-  Send(p, q, opt, x, t, g) -> p ^ show_channel_option opt ^ q ^ ": " ^ x ^ " = " ^ show_term t ^ "\n" ^ show_global_type g
-| Compute(p, letb, g) ->
-  p ^ " {\n" ^ show_let_bind letb ^ "}\n" ^ show_global_type g
-| DefGlobal(name, g, g') ->
-  name ^ show_global_type g ^ "\nin\n"^ show_global_type g'
-| CallGlobal(name) ->
-  name ^ "()"
-| Branch(p, q, opt, lb, rb) -> p ^ show_channel_option opt ^ q ^ " {\n\tLeft:" ^ show_global_type lb ^ "\n\tRight:" ^ show_global_type rb ^ "\n}\n"
-| GlobalEnd -> "end\n"
-
-and show_global_type_nr = function
-  Send(p, q, opt, x, t, _) -> p ^ show_channel_option opt ^ q ^ ": " ^ x ^ " = " ^ show_term t ^ " ..."
-| Compute(p, letb, _) ->
-  p ^ " {\n" ^ show_let_bind letb ^ "}...\n"
-| DefGlobal(name, g, _) ->
-  name ^ "()" ^ show_global_type g ^ "\nin...\n"
-| CallGlobal(name) ->
-  name ^ "()"
-| Branch(p, q, opt, _, _) -> p ^ show_channel_option opt ^ q ^ " {\n\tLeft:...\n\tRight:...\n}\n"
-| GlobalEnd -> "end\n"
 
 and show_params = function
   [] -> ""
@@ -464,7 +435,7 @@ let rec compile principals if_prefix orig_env env forms funs evs gfuns princ gt 
          LEvent(name, terms, compile_letb inner_env return_type next)
        else compile_letb inner_env return_type next
      | IfBlock(cond, thenb, elseb) ->
-       get_term_type (get_penv inner_env p) forms funs cond;
+       let _ = get_term_type (get_penv inner_env p) forms funs cond in
        if p = princ then
         let penv = get_penv inner_env princ in
         let free_vars = get_free_variables gfuns [] princ g [] in


### PR DESCRIPTION
# Details
- Allowing **If blocks** instead of just if assignments;
  - <details><summary><b>If blocks</b></summary>
    </br>

     > SST notation
    ```
    . . .
    Bob {
        if (z_nb = nb) {
            event end_b(nb);
        }
    }
    ``` 

    > ProVerif output
    ```
    let Bob() = 
        . . .
        if z_nb = nb then
            event end_b(nb);
            0.
    ``` 

    > Rust output
    ```
    fn Bob(. . .) {
        if z_nb == nb {
            close(c_BA);
        } else {
            close(c_BA);
        };
    }
    ```
    </details>

    - Also possible to have and if statement without an `else` block;
    </br>

  - <details><summary><b>If assignments</b> <em>(for comparison)</em></summary>
    </br>

    > A & B notation
    ```
    . . .
    Bob {
        let result = if(gxy = gyx, t, f);
    }
    ``` 

    > ProVerif output
    ```
    let Bob() = 
        . . .
        new t: key;
        new f: key;
        let result = ( if(gxy = gyx) then t else f ) in
        0.
    ``` 

    > Rust output
    ```
    fn Bob(. . .) {
        let result = if gxy = gyx {
            t;
        } else {
            f;
        };
    }
    ```
    </details>

- Changed our own data type `None` to `DNone` due to OCaml's type with the same name;
- Type checking is also supported for if blocks;
- Adding Needham Schroeder protocol to represent queries and if statements;
- Pattern matching in Rust in Tuples now works.
- You can now chain events on the left side of a CorrQuery like the ProVerif syntax allows for:
  - SST Notation
  ```
  Queries: event(event1()) & event(event2()) => event(event3());
  ```
  
  - Proverif output
  ```
  query (event(event1()) && event(event2()) ==> event(event3()).
  ```

---
- ❗*If a condition composed of several individual conditions has to be evaluated we need to wrap then in ( ) like:*
  <code>if(<b>(checkzkpokenc(ctc, pzkenc) = OK())</b> & <b>(checkzkpok(b, pzk) = OK()</b>), pextract(msk, b), p)</code>